### PR TITLE
Bug fix for pokemon seed

### DIFF
--- a/seeds/pokemon.js
+++ b/seeds/pokemon.js
@@ -9,7 +9,7 @@ module.exports = [
     "name": "Venusaur",
     "pokedex": "003",
     "evolves_from": "Ivysaur",
-    "image": "https://upload.wikimedia.org/wikipedia/en/d/dd/1200px-003Venusaur.png"
+    "image": "https://img.pokemondb.net/artwork/venusaur.jpg"
   },
   {
     "name": "Charmander",


### PR DESCRIPTION
The image url in the pokemon seed for Venasaur is no longer active; it returns a status code of 404. I changed the url to a site that has an image of that pokemon.